### PR TITLE
Add toggl Enablement parameter to config file

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,6 +18,7 @@ const confTpl = `# pomodoro:
 #   short_break_sec: {{ .Pomodoro.ShortBreakSec }}
 #   long_break_sec: {{ .Pomodoro.LongBreakSec }}
 # toggl:
+#   enable: false
 #   # https://toggl.com/app/xxxx/projects/{project_id}/team
 #   project_id:
 #   # Toggl API token ref: https://toggl.com/app/profile


### PR DESCRIPTION
## Summary

- Added the missing activation parameter for `toggl` during the `gomodoro init` process.

## Why It Was Done

- I was a bit confused when I wanted to log records to toggl and didn't realize it required an enable parameter.

## Verification

- A config file with the enable parameter activated is created during `gomodoro init`.
- `gomodoro start` works properly with these parameters:
    - toggl: enable: true, project_id: a specific project, api_token: my token
    - Other settings remain default.

----------------

## 概要

- `gomodoro init` の際に、 `toggl` の有効化パラメーターが抜けていたため追加しました

## なぜやったのか

- 私がtogglに記録をしたいと思った時に、enableパラメーターを要することを知らずに、少し戸惑ったためです

## 動作確認

- `gomodoro init` でenableパラメーターを有効にしたcofigファイルが作成されること
- これらパラメーターで問題なく `gomodoro start` が機能すること
    - toggl: enable: true, project_id: 特定のプロジェクト, api_token: 私のトークン
    - 他設定はデフォルトのまま