### PR TITLE
Migrate GoReleaser to v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GoReleaser v2 has breaking changes that stop supporting some options. Gomodoro repository uses that one. 
https://goreleaser.com/blog/goreleaser-v2/#upgrading