### PR TITLE
Replace int32 of gqlgen with int

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -44,20 +44,3 @@ models:
   UUID:
     model:
       - github.com/99designs/gqlgen/graphql.UUID
-
-  # The GraphQL spec explicitly states that the Int type is a signed 32-bit
-  # integer. Using Go int or int64 to represent it can lead to unexpected
-  # behavior, and some GraphQL tools like Apollo Router will fail when
-  # communicating numbers that overflow 32-bits.
-  #
-  # You may choose to use the custom, built-in Int64 scalar to represent 64-bit
-  # integers, or ignore the spec and bind Int to graphql.Int / graphql.Int64
-  # (the default behavior of gqlgen). This is fine in simple use cases when you
-  # do not need to worry about interoperability and only expect small numbers.
-  Int:
-    model:
-      - github.com/99designs/gqlgen/graphql.Int32
-  Int64:
-    model:
-      - github.com/99designs/gqlgen/graphql.Int
-      - github.com/99designs/gqlgen/graphql.Int64

--- a/internal/graph/conv/event.go
+++ b/internal/graph/conv/event.go
@@ -47,11 +47,11 @@ func ConvertPomodoroEventToModelEvent(evt event.PomodoroEvent) (*model.Event, er
 	payload := &model.EventPomodoroPayload{
 		ID:            evt.ID,
 		State:         state,
-		RemainingTime: int32(evt.RemainingTime.Seconds()),
-		ElapsedTime:   int32(evt.ElapsedTime.Seconds()),
+		RemainingTime: int(evt.RemainingTime.Seconds()),
+		ElapsedTime:   int(evt.ElapsedTime.Seconds()),
 		TaskID:        &evt.TaskID,
 		Phase:         phase,
-		PhaseCount:    int32(evt.PhaseCount), // #nosec G115
+		PhaseCount:    evt.PhaseCount,
 	}
 
 	return &model.Event{

--- a/internal/graph/conv/pomodoro.go
+++ b/internal/graph/conv/pomodoro.go
@@ -28,9 +28,9 @@ func FromPomodoro(pomodoro *core.Pomodoro) (*model.Pomodoro, error) {
 		TaskID:    pomodoro.TaskID,
 		StartTime: pomodoro.StartTime,
 		Phase:     phase,
-		//nolint:gosec
-		PhaseCount:       int32(pomodoro.PhaseCount),
-		RemainingTimeSec: int32(pomodoro.RemainingTime.Seconds()),
-		ElapsedTimeSec:   int32(pomodoro.ElapsedTime.Seconds()),
+
+		PhaseCount:       pomodoro.PhaseCount,
+		RemainingTimeSec: int(pomodoro.RemainingTime.Seconds()),
+		ElapsedTimeSec:   int(pomodoro.ElapsedTime.Seconds()),
 	}, nil
 }

--- a/internal/graph/generated.go
+++ b/internal/graph/generated.go
@@ -1223,9 +1223,9 @@ func (ec *executionContext) _EventPomodoroPayload_remainingTime(ctx context.Cont
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int32)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2int32(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_EventPomodoroPayload_remainingTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -1267,9 +1267,9 @@ func (ec *executionContext) _EventPomodoroPayload_elapsedTime(ctx context.Contex
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int32)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2int32(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_EventPomodoroPayload_elapsedTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -1396,9 +1396,9 @@ func (ec *executionContext) _EventPomodoroPayload_phaseCount(ctx context.Context
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int32)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2int32(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_EventPomodoroPayload_phaseCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2514,9 +2514,9 @@ func (ec *executionContext) _Pomodoro_phaseCount(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int32)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2int32(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Pomodoro_phaseCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2558,9 +2558,9 @@ func (ec *executionContext) _Pomodoro_remainingTimeSec(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int32)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2int32(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Pomodoro_remainingTimeSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2602,9 +2602,9 @@ func (ec *executionContext) _Pomodoro_elapsedTimeSec(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int32)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2int32(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Pomodoro_elapsedTimeSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3447,9 +3447,9 @@ func (ec *executionContext) _TaskConnection_totalCount(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int32)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2int32(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_TaskConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -5581,21 +5581,21 @@ func (ec *executionContext) unmarshalInputStartPomodoroInput(ctx context.Context
 		switch k {
 		case "workDurationSec":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("workDurationSec"))
-			data, err := ec.unmarshalNInt2int32(ctx, v)
+			data, err := ec.unmarshalNInt2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.WorkDurationSec = data
 		case "breakDurationSec":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("breakDurationSec"))
-			data, err := ec.unmarshalNInt2int32(ctx, v)
+			data, err := ec.unmarshalNInt2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.BreakDurationSec = data
 		case "longBreakDurationSec":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("longBreakDurationSec"))
-			data, err := ec.unmarshalNInt2int32(ctx, v)
+			data, err := ec.unmarshalNInt2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -6835,14 +6835,14 @@ func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.Selec
 	return res
 }
 
-func (ec *executionContext) unmarshalNInt2int32(ctx context.Context, v any) (int32, error) {
-	res, err := graphql.UnmarshalInt32(v)
+func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v any) (int, error) {
+	res, err := graphql.UnmarshalInt(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNInt2int32(ctx context.Context, sel ast.SelectionSet, v int32) graphql.Marshaler {
+func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
 	_ = sel
-	res := graphql.MarshalInt32(v)
+	res := graphql.MarshalInt(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -27,11 +27,11 @@ type Event struct {
 type EventPomodoroPayload struct {
 	ID            string        `json:"id"`
 	State         PomodoroState `json:"state"`
-	RemainingTime int32         `json:"remainingTime"`
-	ElapsedTime   int32         `json:"elapsedTime"`
+	RemainingTime int           `json:"remainingTime"`
+	ElapsedTime   int           `json:"elapsedTime"`
 	TaskID        *string       `json:"taskId,omitempty"`
 	Phase         PomodoroPhase `json:"phase"`
-	PhaseCount    int32         `json:"phaseCount"`
+	PhaseCount    int           `json:"phaseCount"`
 }
 
 func (EventPomodoroPayload) IsEventPayload() {}
@@ -69,18 +69,18 @@ type Pomodoro struct {
 	TaskID           string        `json:"taskId"`
 	StartTime        time.Time     `json:"startTime"`
 	Phase            PomodoroPhase `json:"phase"`
-	PhaseCount       int32         `json:"phaseCount"`
-	RemainingTimeSec int32         `json:"remainingTimeSec"`
-	ElapsedTimeSec   int32         `json:"elapsedTimeSec"`
+	PhaseCount       int           `json:"phaseCount"`
+	RemainingTimeSec int           `json:"remainingTimeSec"`
+	ElapsedTimeSec   int           `json:"elapsedTimeSec"`
 }
 
 type Query struct {
 }
 
 type StartPomodoroInput struct {
-	WorkDurationSec      int32  `json:"workDurationSec"`
-	BreakDurationSec     int32  `json:"breakDurationSec"`
-	LongBreakDurationSec int32  `json:"longBreakDurationSec"`
+	WorkDurationSec      int    `json:"workDurationSec"`
+	BreakDurationSec     int    `json:"breakDurationSec"`
+	LongBreakDurationSec int    `json:"longBreakDurationSec"`
 	TaskID               string `json:"taskId"`
 }
 
@@ -97,7 +97,7 @@ type Task struct {
 type TaskConnection struct {
 	Edges      []*TaskEdge `json:"edges,omitempty"`
 	PageInfo   *PageInfo   `json:"pageInfo"`
-	TotalCount int32       `json:"totalCount"`
+	TotalCount int         `json:"totalCount"`
 }
 
 type TaskEdge struct {

--- a/internal/graph/resolver/task.resolvers.go
+++ b/internal/graph/resolver/task.resolvers.go
@@ -59,7 +59,7 @@ func (r *queryResolver) Tasks(ctx context.Context) (*model.TaskConnection, error
 
 	return &model.TaskConnection{
 		Edges:      edges,
-		TotalCount: int32(len(tasks)),
+		TotalCount: len(tasks),
 		PageInfo: &model.PageInfo{
 			StartCursor:     conv.ToPointer(edges[0].Cursor),
 			EndCursor:       conv.ToPointer(edges[len(edges)-1].Cursor),


### PR DESCRIPTION
## WHAT
This pull request refactors the GraphQL schema and related code to replace `int32` with `int` for various fields and methods. This change aims to simplify the codebase and improve consistency by aligning with Go's default integer type. The most important changes include updates to the GraphQL schema, resolver methods, and generated code.

### GraphQL Schema Updates:
* Updated the `gqlgen.yml` file to remove `Int32` and `Int64` custom scalar mappings, aligning the schema with Go's default `int` type.
* Changed data types in `internal/graph/model/models_gen.go`, replacing `int32` with `int` for fields like `RemainingTime`, `ElapsedTime`, `PhaseCount`, and `TotalCount`. [[1]](diffhunk://#diff-9561e0dc8b36138853150554df04013c52fb5d1e8749763b4e9797034ec26c1eL30-R34) [[2]](diffhunk://#diff-9561e0dc8b36138853150554df04013c52fb5d1e8749763b4e9797034ec26c1eL72-R83) [[3]](diffhunk://#diff-9561e0dc8b36138853150554df04013c52fb5d1e8749763b4e9797034ec26c1eL100-R100)

### Resolver and Conversion Logic Updates:
* Updated resolver methods in `internal/graph/generated.go` and `internal/graph/resolver/task.resolvers.go` to work with `int` instead of `int32`. This includes changes to marshaling/unmarshaling and return types. [[1]](diffhunk://#diff-214d232140aecfe5b98a73a5b28da3e775885a2bb564623961a816f26cab261cL1226-R1228) [[2]](diffhunk://#diff-214d232140aecfe5b98a73a5b28da3e775885a2bb564623961a816f26cab261cL5584-R5598) [[3]](diffhunk://#diff-f4a34e0a335ec3927981c8d1e0af0a74adb0e8f129a3945ed5c0bcfdfa11f6d6L62-R62)
* Modified conversion functions in `internal/graph/conv/event.go` and `internal/graph/conv/pomodoro.go` to use `int` for fields like `RemainingTime` and `ElapsedTime`. [[1]](diffhunk://#diff-e2095339657fac6cc526b75aae6dc6be68bd7a371a4d0c5d3fcd7294ed5f6a49L50-R54) [[2]](diffhunk://#diff-d4668d79e5a55c941be11372485a20922bfe8b894050e9e9f83464f88a7b7da6L31-R34)

### Generated Code Adjustments:
* Regenerated code in `internal/graph/generated.go` to reflect the schema changes, replacing `marshalNInt2int32` and `unmarshalNInt2int32` with `marshalNInt2int` and `unmarshalNInt2int`.

These changes ensure the codebase is more consistent and reduces potential issues with `int32` and `int` interoperability.

## WHY
https://github.com/hatappi/gomodoro/issues/254