### PR TITLE
suppress cancel error

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -87,7 +87,7 @@ func runTUIApp(ctx context.Context, cfg *config.Config) error {
 	startErr := app.Run(ctx)
 	if startErr != nil {
 		if errors.Is(startErr, gomodoro_error.ErrCancel) {
-			log.FromContext(ctx).Info("Pomodoro session canceled by user.")
+			log.FromContext(ctx).V(1).Info("Pomodoro session canceled by user.")
 			return nil
 		}
 

--- a/internal/client/graphql/client.go
+++ b/internal/client/graphql/client.go
@@ -5,6 +5,7 @@ package graphql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -87,7 +88,10 @@ func (c *ClientWrapper) DisconnectSubscription() error {
 	}
 
 	err := c.subscriptionClient.Close()
-	if err != nil {
+
+	// This error indicates that the client was already closed.
+	// It's safe to ignore this error.
+	if err != nil && !errors.Is(err, websocket.ErrCloseSent) {
 		return fmt.Errorf("failed to close subscription client: %w", err)
 	}
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -210,12 +210,7 @@ func (a *App) Run(ctx context.Context) error {
 }
 
 // Finish cleans up resources when the app is closed.
-func (a *App) Finish(ctx context.Context) {
-	_, err := a.graphqlClient.StopPomodoro(ctx)
-	if err != nil {
-		log.FromContext(ctx).Error(err, "failed to stop pomodoro on finish")
-	}
-
+func (a *App) Finish(_ context.Context) {
 	a.screenClient.Finish()
 }
 


### PR DESCRIPTION
This pull request includes several changes aimed at improving logging, error handling, and resource cleanup in the codebase. The most important updates include refining log verbosity, enhancing error handling for subscription disconnection, and simplifying the cleanup process in the `Finish` method.

### Logging Improvements:
* [`cmd/start.go`](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eL90-R90): Adjusted the log level for user-canceled Pomodoro sessions from `Info` to `V(1)` for less intrusive logging.

### Error Handling Enhancements:
* [`internal/client/graphql/client.go`](diffhunk://#diff-83931cfe82d471bdfcad7395687ca2617b9fce4265cf6cfa890bfd25c61401c1L90-R94): Added error handling to ignore `websocket.ErrCloseSent` during subscription client disconnection, as it indicates a safe-to-ignore scenario.
* [`internal/client/graphql/client.go`](diffhunk://#diff-83931cfe82d471bdfcad7395687ca2617b9fce4265cf6cfa890bfd25c61401c1R8): Imported the `errors` package to support the new error handling logic.

### Resource Cleanup Simplification:
* [`internal/tui/app.go`](diffhunk://#diff-eece8b2f502d3f7fb6605c99deb4ae91d5c8d01d5b4a1fe82201cc0283d09341L213-R213): Simplified the `Finish` method by removing the call to `StopPomodoro` and its associated error handling, as it is no longer needed.