### PR TITLE
Refactor Tasks resolver to improve readability by extracting PageInfo initialization

### DIFF
--- a/internal/graph/resolver/task.resolvers.go
+++ b/internal/graph/resolver/task.resolvers.go
@@ -57,15 +57,20 @@ func (r *queryResolver) Tasks(ctx context.Context) (*model.TaskConnection, error
 		})
 	}
 
+	pageInfo := &model.PageInfo{
+		HasNextPage:     false,
+		HasPreviousPage: false,
+	}
+
+	if len(tasks) > 0 {
+		pageInfo.StartCursor = conv.ToPointer(edges[0].Cursor)
+		pageInfo.EndCursor = conv.ToPointer(edges[len(edges)-1].Cursor)
+	}
+
 	return &model.TaskConnection{
 		Edges:      edges,
 		TotalCount: len(tasks),
-		PageInfo: &model.PageInfo{
-			StartCursor:     conv.ToPointer(edges[0].Cursor),
-			EndCursor:       conv.ToPointer(edges[len(edges)-1].Cursor),
-			HasNextPage:     false,
-			HasPreviousPage: false,
-		},
+		PageInfo:   pageInfo,
 	}, nil
 }
 


### PR DESCRIPTION
This pull request refactors the `Tasks` resolver to improve readability and reduce redundancy by introducing a reusable `PageInfo` object. The most notable change is the separation of `PageInfo` initialization logic from the `TaskConnection` return statement.

Improvements to code readability and maintainability:

* [`internal/graph/resolver/task.resolvers.go`](diffhunk://#diff-f4a34e0a335ec3927981c8d1e0af0a74adb0e8f129a3945ed5c0bcfdfa11f6d6R60-R73): Introduced a `pageInfo` variable to encapsulate the logic for initializing the `PageInfo` object, reducing redundancy and improving clarity. The `PageInfo` initialization now handles cases where the `tasks` list is empty, ensuring no out-of-bounds errors when accessing `edges`.