### PR TITLE
Add API address configuration to DefaultConfig

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -26,7 +26,10 @@ const confTpl = `# pomodoro:
 #   # Toggl API token ref: https://toggl.com/app/profile
 #   api_token:
 # log_file: {{ .LogFile }}
-
+#
+# api:
+#  addr: localhost:8080
+#
 ## You can change the colors used within gomodoro.
 ## You need to specify W3C Color name (e.g. red) or HEX (.e.g. #ffffff)
 # color:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,7 @@ func DefaultConfig() *Config {
 			Cursor:              tcell.ColorGreen,
 		},
 		API: APIConfig{
+			Addr:         "localhost:8080",
 			ReadTimeout:  time.Second * DefaultAPITimeout,
 			WriteTimeout: time.Second * DefaultAPITimeout,
 		},


### PR DESCRIPTION
This pull request introduces changes to add support for configuring an API address in the application. The updates include modifications to the default configuration and the template configuration file.

Configuration updates:

* [`cmd/init.go`](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acL29-R32): Added new fields in the template configuration file (`confTpl`) to specify an API address (`addr`).
* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR119): Updated the `DefaultConfig` function to set a default API address (`localhost:8080`) in the `APIConfig` struct.