### PR TITLE
Add foreground color option for selected task in renderTasks

### DIFF
--- a/internal/tui/view/task_view.go
+++ b/internal/tui/view/task_view.go
@@ -160,6 +160,7 @@ func (v *TaskView) renderTasks(tasks []*core.Task, offset, renderbleNum, cursorP
 		if y == cursorPosition {
 			opts = []draw.Option{
 				draw.WithBackgroundColor(v.config.Color.SelectedLine),
+				draw.WithForegroundColor(v.config.Color.Font),
 			}
 		}
 		tw := runewidth.StringWidth(name)


### PR DESCRIPTION
This pull request includes a small change to the `renderTasks` method in `internal/tui/view/task_view.go`. The change adds a foreground color option to the selected line rendering logic to improve visual clarity.