### PR TITLE
Fix remaining time calculation by converting to seconds before computing minutes and seconds

### DIFF
--- a/cmd/remain.go
+++ b/cmd/remain.go
@@ -50,8 +50,9 @@ func newRemainCmd() *cobra.Command {
 
 			var remainingStr string
 			if slices.Contains([]event.PomodoroState{event.PomodoroStateActive, event.PomodoroStatePaused}, pomodoro.State) {
-				minutes := pomodoro.RemainingTime / secondsPerMinute
-				seconds := pomodoro.RemainingTime % secondsPerMinute
+				sec := int(pomodoro.RemainingTime.Seconds())
+				minutes := sec / secondsPerMinute
+				seconds := sec % secondsPerMinute
 
 				remainingStr = fmt.Sprintf("%02d:%02d", minutes, seconds)
 			} else {


### PR DESCRIPTION
This pull request includes a small change to the `cmd/remain.go` file. It updates the calculation of remaining time by converting `pomodoro.RemainingTime` to seconds using the `Seconds()` method before performing the division and modulo operations.